### PR TITLE
Fix docker build (preventing tsc build after every npm (c)i)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,8 @@ USER node
 
 COPY --chown=node:node . .
 
-RUN npm ci
 RUN npm run clean
-RUN npm run build
+RUN npm ci
 
 FROM node:12-alpine AS app-prod
 
@@ -24,7 +23,7 @@ COPY --from=app-builder --chown=node:node /usr/src/app/dist ./dist
 COPY --from=app-builder --chown=node:node /usr/src/app/bin ./bin
 COPY --chown=node:node package*.json ./
 
-RUN npm ci --only=production
+RUN npm ci --only=production --ignore-scripts
 
 EXPOSE 8080
 EXPOSE 8081

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "prepack": "npm run build",
     "clean": "rm -rf ./dist/* ",
     "build": "./node_modules/typescript/bin/tsc",
     "build-watch": "./node_modules/typescript/bin/tsc -w",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prepare": "npm run build",
     "clean": "rm -rf ./dist/* ",
     "build": "./node_modules/typescript/bin/tsc",
     "build-watch": "./node_modules/typescript/bin/tsc -w",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prepack": "npm run build",
     "clean": "rm -rf ./dist/* ",
     "build": "./node_modules/typescript/bin/tsc",
     "build-watch": "./node_modules/typescript/bin/tsc -w",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "prepare": "npm run build",
     "clean": "rm -rf ./dist/* ",
     "build": "./node_modules/typescript/bin/tsc",
     "build-watch": "./node_modules/typescript/bin/tsc -w",


### PR DESCRIPTION
I noticed I could not build a docker container without adding `typescript` as a production dependency.  

I removed the 'prepare' step from the `package.json` to prevent a build being done after every `npm (c)i`. 